### PR TITLE
Undefined name: app --> self.app

### DIFF
--- a/maxfw/core/app.py
+++ b/maxfw/core/app.py
@@ -28,7 +28,7 @@ class MAXApp(object):
         # enable cors if flag is set
         if os.getenv('CORS_ENABLE') == 'true' and \
         os.environ.get('WERKZEUG_RUN_MAIN') == 'true':
-            CORS(app, origins='*')
+            CORS(self.app, origins='*')
             self.app.logger.info(
             'NOTE: MAX Model Server is currently allowing ' + \
             'cross-origin requests - (CORS ENABLED)')


### PR DESCRIPTION
__app__ is an _undefined name_ in this context which has the potential to raise NameError at runtime so this PR proposes the use of __self.app__ instead.

[flake8](http://flake8.pycqa.org) testing of https://github.com/IBM/MAX-Framework on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./maxfw/core/app.py:31:18: F821 undefined name 'app'
            CORS(app, origins='*')
                 ^
1     F821 undefined name 'app'
1
```