### PR TITLE
Add 2 metadata fields, in addition to updating the Flask app name

### DIFF
--- a/maxfw/core/api.py
+++ b/maxfw/core/api.py
@@ -6,6 +6,8 @@ METADATA_SCHEMA = MAX_API.model('ModelMetadata', {
         'id': fields.String(required=True, description='Model identifier'),
         'name': fields.String(required=True, description='Model name'),
         'description': fields.String(required=True, description='Model description'),
+        'type': fields.String(required=True, description='Model type'),
+        'source': fields.String(required=True, description='Model source'),
         'license': fields.String(required=False, description='Model license')
     })
 

--- a/maxfw/core/app.py
+++ b/maxfw/core/app.py
@@ -9,8 +9,8 @@ MAX_API = Namespace('model', description='Model information and inference operat
 
 class MAXApp(object):
 
-    def __init__(self, title=API_TITLE, desc=API_DESC, version=API_VERSION, name=__name__):
-        self.app = Flask(name)
+    def __init__(self, title=API_TITLE, desc=API_DESC, version=API_VERSION):
+        self.app = Flask(title)
 
         # load config
         if os.path.exists("config.py"):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='maxfw',
-      version='1.1',
+      version='1.1.0',
       description='A package to simplify the creation of MAX models',
       url='https://github.com/IBM/MAX-Framework',
       author='CODAIT',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='maxfw',
-      version='0.1',
+      version='1.1',
       description='A package to simplify the creation of MAX models',
       url='https://github.com/IBM/MAX-Framework',
       author='CODAIT',


### PR DESCRIPTION
As a response to @MLnick his request (#5), I have updated the Flask app name to the API title.

In addition to allow @bdwyer2 to proceed with downstream conversion of the Object Detector, we need to add a 'type' and 'source' field. (ref https://github.com/IBM/MAX-Object-Detector/pull/36)

@ reviewers, a couple questions to allow me to proceed:
- Should we expand the default_config.py file? I think so?!
- Should we add the 'type', 'source', and 'license' fields to the following in 'app.py' line 19 to get the metadata to show? No easy way to test this out since this is the framework, so I will rely on your insight for this one.
```
        self.api = Api(
            self.app,
            title=title,
            description=desc,
            version=version)
```

As always, appreciate the feedback!