### PR TITLE
Redo the versioning changes: v1.1.0 to v1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='maxfw',
-      version='1.1.0',
+      version='1.0.0',
       description='A package to simplify the creation of MAX models',
       url='https://github.com/IBM/MAX-Framework',
       author='CODAIT',


### PR DESCRIPTION
In [this](https://github.com/IBM/MAX-Framework/pull/6) PR the version was updated to be consistent with the next MAX-Base release. In hindsight, there is no reason to follow the MAX-base versioning. In order to avoid confusion, this PR edits the version number.

@djalova @bdwyer2 