### PR TITLE
Extend core.app.run to accept port parameter

### DIFF
--- a/maxfw/core/app.py
+++ b/maxfw/core/app.py
@@ -39,4 +39,4 @@ class MAXApp(object):
             return self.app.send_static_file('index.html')
 
     def run(self, host='0.0.0.0', port='5000'):
-        self.app.run(host, port)
+        self.app.run(host=host, port=port)

--- a/maxfw/core/app.py
+++ b/maxfw/core/app.py
@@ -38,5 +38,5 @@ class MAXApp(object):
         def index():
             return self.app.send_static_file('index.html')
 
-    def run(self, host='0.0.0.0'):
-        self.app.run(host)
+    def run(self, host='0.0.0.0', port='5000'):
+        self.app.run(host, port)


### PR DESCRIPTION
Allow core.app.run to accept port parameter which is useful when we deploy MAX models on platforms with non-configurable port (e.g. Cloud Foundry, Heroku)