### PR TITLE
Inherit MAXModelWrapper from ABC.

### DIFF
--- a/maxfw/model/model.py
+++ b/maxfw/model/model.py
@@ -1,7 +1,7 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 
-class MAXModelWrapper(object):
+class MAXModelWrapper(ABC):
     @abstractmethod
     def __init__(self, path=None):
         """Implement code to load model here"""


### PR DESCRIPTION
abstractmethod decorator won't be effective unless the class inherits from ABC. See https://docs.python.org/3/library/abc.html#abc.abstractmethod