### PR TITLE
Remove abstract method decorator from optional methods

### DIFF
--- a/maxfw/model/model.py
+++ b/maxfw/model/model.py
@@ -2,17 +2,14 @@ from abc import ABC, abstractmethod
 
 
 class MAXModelWrapper(ABC):
-    @abstractmethod
     def __init__(self, path=None):
         """Implement code to load model here"""
         pass
 
-    @abstractmethod
     def _pre_process(self, x):
         """Implement code to process raw input into format required for model inference here"""
         return x
 
-    @abstractmethod
     def _post_process(self, x):
         """Implement any code to post-process model inference response here"""
         return x

--- a/maxfw/model/model.py
+++ b/maxfw/model/model.py
@@ -17,7 +17,7 @@ class MAXModelWrapper(ABC):
     @abstractmethod
     def _predict(self, x):
         """Implement core model inference code here"""
-        return x
+        pass
 
     def predict(self, x):
         pre_x = self._pre_process(x)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name='maxfw',
-      version='1.1.2',
+      version='1.1.3',
       description='A package to simplify the creation of MAX models',
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR removes the abstractmethod decorator from `__init__()`, `_pre_process()`, and `_post_process()` from the `MAXModelWrapper` class.

Bumps version to 1.1.3